### PR TITLE
feat: remove access policy due to deprecation

### DIFF
--- a/policies.tf
+++ b/policies.tf
@@ -1,24 +1,3 @@
-# ACCESS POLICY
-#
-# This example access policy gives everyone in the "Engineering" GitHub team
-# read access to the stack.
-#
-# You can read more about access policies here:
-#
-# https://docs.spacelift.io/concepts/policy/stack-access-policy
-resource "spacelift_policy" "access" {
-  type = "ACCESS"
-
-  name = "All of Engineering gets read access"
-  body = file("${path.module}/policies/access.rego")
-}
-
-# Access policies only take effect when attached to the stack.
-resource "spacelift_policy_attachment" "access" {
-  policy_id = spacelift_policy.access.id
-  stack_id  = data.spacelift_current_stack.this.id
-}
-
 # PLAN POLICY
 #
 # This example plan policy prevents you from creating weak passwords, and warns 


### PR DESCRIPTION
Access policies seem to be deprecated:
```
│ Error: could not create policy All of Engineering gets read access: cannot create stack access policies outside of legacy space
│ 
│   with spacelift_policy.access,
│   on policies.tf line 9, in resource "spacelift_policy" "access":
│    9: resource "spacelift_policy" "access" {
```

I discovered this during my onboarding when I created the showcase stack.